### PR TITLE
Fixes for Current YouTube Layout

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -122,7 +122,7 @@ class NewLayout {
 				}
 			}, 10);
 		}).then((successMessage) => {
-			var subbed_channel_names = $("div#sections > :nth-child(3) > div#items").find("ytd-guide-entry-renderer:not(#expander-item):not(#collapser-item):not(:last-child)");
+			var subbed_channel_names = $("div#sections > :nth-child(2) > div#items").find("ytd-guide-entry-renderer:not(#expander-item):not(#collapser-item):not(:last-child)");
 			subbed_channel_names = subbed_channel_names.map(function() {return $.trim($(this).find("span.title").eq(0).text())}).get();
 			// for some reason, random subs will have periods after their names on the sidebar, so strip those
 			subbed_channel_names = $.map(subbed_channel_names, function(sub, i) {
@@ -154,7 +154,7 @@ class NewLayout {
 		if ($("div#expandable-items").children().length === 0) {
 			$("#expander-item").click();
 		}
-		var subbed_channel_names = $("div#sections > :nth-child(3) > div#items").find("ytd-guide-entry-renderer:not(#expander-item):not(#collapser-item):not(:last-child)");
+		var subbed_channel_names = $("div#sections > :nth-child(2) > div#items").find("ytd-guide-entry-renderer:not(#expander-item):not(#collapser-item):not(:last-child)");
 		subbed_channel_names = subbed_channel_names.map(function() {return $.trim($(this).find("span.title").eq(0).text())}).get();
 		var trending_video_elements = $("ytd-video-renderer, ytd-grid-video-renderer");
 		var trending_video_names = trending_video_elements.map(function() {
@@ -195,8 +195,8 @@ class NewLayout {
 			recommendations.eq(0).hide();
 			$(".ytp-next-button").hide();
 			$("video").on("progress", function() {
-				if ($("#improved-toggle").attr("aria-pressed") === "true") {
-					$("#improved-toggle").click();
+				if ($("#toggle").attr("aria-pressed") === "true") {
+					$("#toggle").click();
 				}
 			});
 		}
@@ -208,6 +208,10 @@ class NewLayout {
 		// (and most of the time, it's right)
 		if ($("ytd-playlist-panel-renderer").attr("hidden") !== "hidden") {
 			recommendations.eq(0).hide();
+			// Check for empty playlist that is still visible and remove the motherfucker
+			if($("ytd-playlist-panel-renderer").length){
+				$("ytd-playlist-panel-renderer").hide();
+			}
 		}
 
 		// check the recommendation directly below autoplay to see if it's a mix

--- a/js/main.js
+++ b/js/main.js
@@ -189,7 +189,12 @@ class NewLayout {
 		var channel_name = $("#owner-name > a").text();
 		var recommendations = $("div#related div#items > *");
 
-		// autoplay check
+		// autoplay prevention check
+		// In my testing, the control was not toggled off properly so it must include the block below
+		if ($("#toggle").attr("aria-pressed") === "true") {
+			$("#toggle").click();
+		}
+
 		var rec_name = recommendations.eq(0).find("yt-formatted-string").text();
 		if (rec_name !== channel_name) {
 			recommendations.eq(0).hide();

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 		{
 			"matches": ["*://*.youtube.com/*"],
 			"run_at": "document_start",
-			"js": ["js/jquery-3.2.1.min.js", "js/main.js"]
+			"js": ["js/jquery-3.4.1.min.js", "js/main.js"]
 		}
 	],
 	"icons": {


### PR DESCRIPTION
This extension looks like a good idea, so I'm proposing fixes for the following:
- Remove recommendations based on the right element. The one that actually contains the subscribers list in the latest YouTube layout.
- Properly toggle off autoplaying
- Remove playlist element if empty
- Modified manifest file to reference latest JQuery

I may work on adding a keyword blacklist soon.

_This PR was thoroughly tested on fresh Chromium snapshots and the Microsoft Edge Dev Channel._